### PR TITLE
Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 In Japan, a schoolgirl was caught by the police for writing an endeless loop of aleart in JavaScript like this:
 
         while (1) {
-          aleart("!");
+          alert("!");
         }
 
 Related news article (Japanese):


### PR DESCRIPTION
Fixed a typo: `aleart` -> `alert`. That's it.