### PR TITLE
Remove author language links except for README.md

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,10 +1,3 @@
-- [English](README.md)
-- [日本語](README.ja.md)
-- [한국어](README.ko.md)
-- [Bahasa Indonesia](README.in.md)
-- [Español](README.es.md)
-- [简体中文](README.zh.md)
-
 # Proyecto que-nos-arresten
 
 En Japón, una estudiante fue detenida por la policía por poner un _link_ a un sitio con un búcle infinito de `alerts` en JavaScript, similar a esto:

--- a/README.in.md
+++ b/README.in.md
@@ -1,10 +1,3 @@
-- [English](README.md)
-- [日本語](README.ja.md)
-- [한국어](README.ko.md)
-- [Bahasa Indonesia](README.in.md)
-- [Español](README.es.md)
-- [简体中文](README.zh.md)
-
 # Project-mari-kita-ditangkap
 
 Di Jepang, seorang gadis SMA ditangkap oleh polisi karena meletakkan link menuju ke sebuah website yang  berisi alert menggunakan endless loop pada Javascript seperti berikut:

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,10 +1,3 @@
-- [English](README.md)
-- [日本語](README.ja.md)
-- [한국어](README.ko.md)
-- [Bahasa Indonesia](README.in.md)
-- [Español](README.es.md)
-- [简体中文](README.zh.md)
-
 # みんなで逮捕されようプロジェクト
 
 日本において、以下のようなアラートの無限ループを JavaScript で書いたサイトへのリンクを貼ったことである女子中学生が警察に補導されました:

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,10 +1,3 @@
-- [English](README.md)
-- [日本語](README.ja.md)
-- [한국어](README.ko.md)
-- [Bahasa Indonesia](README.in.md)
-- [Español](README.es.md)
-- [简体中文](README.zh.md)
-
 # 체포 프로젝트
 
 일본에서 한 여학생이 다음의 javascript 코드 처럼 무한 alert 팝업이 뜨는 사이트의 링크를 게시판에 올렸다는 이유로 경찰에 체포 되었습니다.

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,10 +1,3 @@
-- [English](README.md)
-- [日本語](README.ja.md)
-- [한국어](README.ko.md)
-- [Bahasa Indonesia](README.in.md)
-- [Español](README.es.md)
-- [简体中文](README.zh.md)
-
 # 大家一起被捕吧计划
 
 在日本，因为贴了一个前往包含下述无限警告循环的 JavaScript 的网站的链接，一名女中学生被警察逮捕并进行辅导：


### PR DESCRIPTION
Having all language links on all pages makes it easy to switch language, but it needs to add the link to all files when adding a new translation.
I think that switching another language from each language pages is rare.
So this PR removes language links except for README.md to reduce the burden on translators.