### PR TITLE
portuguese: translation improvements, better call-to-action

### DIFF
--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,7 +6,7 @@
 - [简体中文](README.zh.md)
 - [Português Brasileiro](README.pt-br.md)
 
-# Projeto todos-foram-presos-juntos
+# Projeto vamos-ser-presos
 
 No Japão, uma aluna foi pega pela polícia por colocar um link para um site com um loop infinito de alerta em JavaScript assim:
 
@@ -21,7 +21,7 @@ Notícias relacionadas ao incidente:
 - (Japonês) [https://www3.nhk.or.jp/lnews/kobe/20190304/2020003239.html](https://www3.nhk.or.jp/lnews/kobe/20190304/2020003239.html)
 - (Inglês) [https://www.zdnet.com/article/japanese-police-charge-13-year-old-for-sharing-unclosable-popup-prank-online/](https://www.zdnet.com/article/japanese-police-charge-13-year-old-for-sharing-unclosable-popup-prank-online/)
 
-Então se isso é considerado um "crime" no Japão. Então vamos ser criminosos e presos!
+Então se isso é considerado um "crime" no Japão. Então vamos ser criminosos e ser presos!
 
 Aproveite a sua vida do crime!
 
@@ -29,6 +29,6 @@ Aproveite a sua vida do crime!
 
 É muito simples. Faça um _fork_ do projeto com a _branch_ chamada `gh-pages` (Se não houver crie). Está tudo pronto. Seria mais eficaz compartilhar a URL "http://youraccount.github.io/lets-get-arrested" em mídias sociais.
 
-## Não há ninguem para prendê-lo ?
+## Não te prenderam?
 
 Você pode se render à polícia.


### PR DESCRIPTION
The translation for "Lets-get-arrested project" is more about
"Projeto vamos-ser-presos" in portuguese, similar to
"Proyecto que-nos-arresten" already used in Spanish. There are other small
variations that could be used, but the actual actual translation
"Projeto todos-foram-presos-juntos" in English is more near the meaning
"Project everyone-were-arrested-together".

```diff
- Então se isso é considerado um "crime" no Japão. Então vamos ser criminosos e ser presos!
+ Então se isso é considerado um "crime" no Japão. Então vamos ser criminosos e presos!
```

This change makes make more clear that there is a difference between just be a
criminal and be arrested. The older explanation assumes that only because is a
criminal would be arrested.

```diff
- ## Não há ninguem para prendê-lo ?
+ ## Não te prenderam?
```

This is a minor change. The old one could still work fine (just missed 'é',
woud be "ninguém", not "ninguem") and alone would not be really strong reason
to make a pull request, but since I'm already doing a pull request this is a bit
better.