### PR TITLE
Fix typo

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -26,4 +26,4 @@ Es simple. _Forkea_ este proyecto y creá un _branch_ llamado `gh-pages`. Eso es
 
 ## ¿No te arrestaron?
 
-Podes entregarte a la policía.
+Podés entregarte a la policía.


### PR DESCRIPTION
When using _voseo_ in spanish, the second person of the present indicative must be written with a graphic accent, as it's last syllabe is phonetically accentuated and it ends with an _s_